### PR TITLE
Change how greeting works and adds it to config

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -32,7 +32,9 @@ pub fn ping(ctx: &mut Context, msg: &Message) -> CommandResult {
 }
 
 #[command]
-#[description("Informação relativa à linguagem de programação utilizada para desenvolvimento do Bot.")]
+#[description(
+    "Informação relativa à linguagem de programação utilizada para desenvolvimento do Bot."
+)]
 pub fn info(ctx: &mut Context, msg: &Message) -> CommandResult {
     msg.channel_id.say(&ctx.http, "Powered by JAVA8™")?;
     Ok(())
@@ -42,7 +44,10 @@ pub fn info(ctx: &mut Context, msg: &Message) -> CommandResult {
 #[description("Apresenta o link para o material de apoio do curso.")]
 #[usage("")]
 pub fn material(ctx: &mut Context, msg: &Message) -> CommandResult {
-    msg.channel_id.say(&ctx.http, "**Este é o link para o material do curso** -> http://bit.ly/materialmiei")?;
+    msg.channel_id.say(
+        &ctx.http,
+        "**Este é o link para o material do curso** -> http://bit.ly/materialmiei",
+    )?;
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,8 @@ use std::sync::{Arc, RwLock};
 pub struct Config {
     #[serde(default)]
     allowed_channels: HashSet<ChannelId>,
+    #[serde(default)]
+    greet_channel: Option<ChannelId>,
 }
 
 const CONFIG: &str = "config.json";
@@ -38,6 +40,20 @@ impl Config {
 
     pub fn remove_allowed_channel(&mut self, ch: ChannelId) -> Result<(), Box<dyn error::Error>> {
         self.allowed_channels.remove(&ch);
+        Config::serialize(self)
+    }
+
+    pub fn greet_channel(&self) -> Option<ChannelId> {
+        self.greet_channel
+    }
+
+    pub fn set_greet_channel(&mut self, greet_channel: ChannelId) -> Result<(), Box<dyn error::Error>> {
+        self.greet_channel = Some(greet_channel);
+        Config::serialize(self)
+    }
+
+    pub fn remove_greet_channel(&mut self) -> Result<(), Box<dyn error::Error>> {
+        self.greet_channel = None;
         Config::serialize(self)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,17 +51,21 @@ impl EventHandler for Handler {
         let config = share_map.get::<Config>().unwrap().read().unwrap();
         if let Some(ch) = config.greet_channel() {
             let user = new_member.user_id();
-            ch.send_message(&ctx, |m| m.embed(|e| {
-                e.title("Bem vindo ao servidor de MIEI!");
-                e.description(format!("{} faz `$study XanoYsem` para teres acesso as salas das cadeiras, para colorares duvidas ou tirares duvidas!", user.mention()));
-                e.thumbnail(guild_id.to_partial_guild(&ctx.http).map(|u|u.icon_url().expect("No Guild Image available")).unwrap());
-                e.colour(Colour::from_rgb(0, 0, 0));
-                e.footer( |f| {
-                    f.text("Qualquer dúvida sobre o bot podes usar $man para saberes o que podes fazer.");
-                    f
+            ch.send_message(&ctx, |m| {
+                m.content(user.mention());
+                m.embed(|e| {
+                    e.title("Bem vindo ao servidor de MIEI!");
+                    e.description("Faz `$study XanoYsem` para teres acesso as salas das cadeiras, para colorares duvidas ou tirares duvidas!");
+                    e.thumbnail(guild_id.to_partial_guild(&ctx.http).map(|u|u.icon_url().expect("No Guild Image available")).unwrap());
+                    e.colour(Colour::from_rgb(0, 0, 0));
+                    e.footer( |f| {
+                        f.text("Qualquer dúvida sobre o bot podes usar $man para saberes o que podes fazer.");
+                        f
+                    });
+                    e
                 });
-                e
-            })).map_err(|e| eprintln!("Couldn't greet new user {}: {:?}", user, e)).ok();
+                m
+            }).map_err(|e| eprintln!("Couldn't greet new user {}: {:?}", user, e)).ok();
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,32 +47,22 @@ impl EventHandler for Handler {
     }
 
     fn guild_member_addition(&self, ctx: Context, guild_id: GuildId, new_member: Member) {
-        new_member
-            .user_id()
-            .to_user(&ctx)
-            .map(|x|
-                x.direct_message(&ctx, |m|{
-                    m.embed(|e| {
-                        e.title("Bem vindo ao servidor de MIEI!");
-                        e.description(format!("O nosso objetivo é facilitar a vossa passagem neste curso, \
-                        através de um servidor com todas as cadeiras, materiais e conteúdos para \
-                        que possam estar sempre a par do que acontece em cada cadeira.
-      Temos também uma sala `#geral` onde podemos conversar de uma forma mais informal e um \
-      conjunto de `#regras` que devem ser cumpridas e que podem sempre consultar com alguma \
-      dúvida que tenham.
-      Temos também o nosso bot {} que permite que te juntes às salas das \
-      cadeiras com o comando `$study CADEIRA1, CADEIRA2, ...` ou, se preferires, podes-te juntar \
-      a todas as cadeiras de um ano com o comando `$study Xano` substituindo o `X` pelo ano que queres.", ctx.cache.read().user.name));
-                        e.footer( |f| {
-                            f.text("Qualquer dúvida sobre o bot podes usar $man para saberes o que podes fazer.");
-                            f
-                        });
-                        e.thumbnail(guild_id.to_partial_guild(&ctx.http).map(|u|u.icon_url().expect("No Guild Image available")).unwrap());
-                        e.colour(Colour::from_rgb(0, 0, 0));
-                        e
-                    });
-                    m
-                })).unwrap().unwrap();
+        let share_map = ctx.data.read();
+        let config = share_map.get::<Config>().unwrap().read().unwrap();
+        if let Some(ch) = config.greet_channel() {
+            let user = new_member.user_id();
+            ch.send_message(&ctx, |m| m.embed(|e| {
+                e.title("Bem vindo ao servidor de MIEI!");
+                e.description(format!("{} faz `$study XanoYsem` para teres acesso as salas das cadeiras, para colorares duvidas ou tirares duvidas!", user.mention()));
+                e.thumbnail(guild_id.to_partial_guild(&ctx.http).map(|u|u.icon_url().expect("No Guild Image available")).unwrap());
+                e.colour(Colour::from_rgb(0, 0, 0));
+                e.footer( |f| {
+                    f.text("Qualquer dúvida sobre o bot podes usar $man para saberes o que podes fazer.");
+                    f
+                });
+                e
+            })).map_err(|e| eprintln!("Couldn't greet new user {}: {:?}", user, e)).ok();
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds the `greet` group to the `sudo` group, and the following commands to the group:
```
sudo greet get
sudo greet set <channel-mention>
sudo greet clear
```
And removes the DM greeting.

The greeting looks like this:
![image](https://user-images.githubusercontent.com/19352680/66753424-b1a8b800-ee8b-11e9-8504-cd62b96bd712.png)
