### PR TITLE
Bug fixes and performance improvements ™

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,7 @@ name = "rusteze"
 version = "0.1.0"
 dependencies = [
  "aho-corasick 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ once_cell = "1"
 rand = "0.7"
 parking_lot = "0.11"
 aho-corasick = "0.7"
+chrono = "0.4"
 
 [profile.release]
 codegen-units = 1

--- a/src/commands/admin.rs
+++ b/src/commands/admin.rs
@@ -29,7 +29,7 @@ use std::{
 use user_groups::USERGROUPS_GROUP;
 
 #[group]
-#[commands(edit, update, say, whitelist)]
+#[commands(edit, update, reboot, say, whitelist)]
 #[required_permissions(ADMINISTRATOR)]
 #[prefixes("sudo")]
 #[sub_groups(Channels, GreetingChannels, LogChannel, Minecraft, Daemons, UserGroups)]
@@ -82,7 +82,7 @@ pub fn whitelist(ctx: &mut Context, msg: &Message, args: Args) -> CommandResult 
 
 #[command]
 #[description("Update the bot")]
-pub fn update(ctx: &mut Context, msg: &Message) -> CommandResult {
+pub fn update(ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
     static UPDATING: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
     let _ = match UPDATING.try_lock() {
         Err(TryLockError::WouldBlock) => return Err("Alreading updating".into()),
@@ -146,6 +146,13 @@ pub fn update(ctx: &mut Context, msg: &Message) -> CommandResult {
     }
     check_msg(message)?;
 
+    reboot(ctx, msg, args)
+}
+
+#[command]
+#[description("Reboot the bot")]
+#[usage("")]
+pub fn reboot(ctx: &mut Context, msg: &Message) -> CommandResult {
     msg.channel_id.say(ctx, "Rebooting...")?;
     std::env::set_var("RUST_BACKTRACE", "1");
     let error = Fork::new("cargo")

--- a/src/commands/cesium.rs
+++ b/src/commands/cesium.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serenity::{
     framework::standard::{
         macros::{check, command, group},
-        Args, CheckResult, CommandOptions, CommandResult, Reason,
+        ArgError, Args, CheckResult, CommandOptions, CommandResult, Reason,
     },
     http::{CacheHttp, Http},
     model::{
@@ -38,7 +38,7 @@ const CHANNELS: &str = "cesium_channels.json";
 #[check]
 #[name = "is_mod_or_cesium"]
 pub fn is_mod_or_cesium(
-    _: &mut Context,
+    ctx: &mut Context,
     msg: &Message,
     _: &mut Args,
     _: &CommandOptions,
@@ -46,10 +46,20 @@ pub fn is_mod_or_cesium(
     msg.member
         .as_ref()
         .and_then(|m| {
-            if [MENTOR_ROLE, CESIUM_ROLE, MODS_ROLE]
-                .iter()
-                .any(|r| m.roles.contains(r))
-            {
+            let is_admin = || {
+                msg.guild_id.map(|id| {
+                    id.member(&ctx, msg.author.id)
+                        .and_then(|u| u.permissions(&ctx))
+                        .map(Permissions::administrator)
+                        .unwrap_or(false)
+                })
+            };
+            let has_role = || {
+                [MENTOR_ROLE, CESIUM_ROLE, MODS_ROLE]
+                    .iter()
+                    .any(|r| m.roles.contains(r))
+            };
+            if has_role() || is_admin()? {
                 Some(CheckResult::Success)
             } else {
                 None
@@ -178,6 +188,7 @@ impl TypeMapKey for ChannelMapping {
 #[command]
 #[description("Adds a new private room")]
 #[usage("[StudentMention...]")]
+#[min_args(1)]
 pub fn add(ctx: &mut Context, msg: &Message, mut args: Args) -> CommandResult {
     let guild_id = msg.guild_id.ok_or("Message with no guild id")?;
     let data_lock = ctx.data.write();
@@ -199,42 +210,38 @@ pub fn remove(ctx: &mut Context, msg: &Message) -> CommandResult {
 }
 
 #[command]
-#[description("Adds a student to a private room")]
-#[usage("[StudentMention]")]
+#[description("Adds a student to a private room, the room is where the command is called or passed as a second parameter")]
+#[usage("StudentMention [channel_mention]")]
+#[min_args(1)]
 pub fn join(ctx: &mut Context, msg: &Message, mut args: Args) -> CommandResult {
     let data_lock = ctx.data.read();
     let channels = data_lock.get::<ChannelMapping>().unwrap().read();
-    let text = msg.channel_id;
-    let voice = channels
-        .get_channel(&text)
-        .ok_or("Invalid channel, use this command in a #mentor-channel-* channel")?;
-    args.iter::<UserId>().try_for_each(|x| {
-        x.map_err(|_| "invalid user id")
-            .and_then(|u| {
-                text.create_permission(
-                    &ctx,
-                    &PermissionOverwrite {
-                        kind: PermissionOverwriteType::Member(u),
-                        allow: Permissions::READ_MESSAGES,
-                        deny: Permissions::empty(),
-                    },
-                )
-                .map(|_| u)
-                .map_err(|_| "Failed to create permission for text channel")
-            })
-            .and_then(|u| {
-                voice
-                    .create_permission(
-                        &ctx,
-                        &PermissionOverwrite {
-                            kind: PermissionOverwriteType::Member(u),
-                            allow: Permissions::READ_MESSAGES,
-                            deny: Permissions::empty(),
-                        },
-                    )
-                    .map_err(|_| "Failed to create permissio for voice channeln")
-            })
-    })?;
+    let user = args.single::<UserId>()?;
+    let text = match args.single::<ChannelId>() {
+        Ok(t) => t,
+        Err(ArgError::Eos) => msg.channel_id,
+        Err(e) => return Err(e.into()),
+    };
+    let voice = channels.get_channel(&text).ok_or(
+        "Invalid channel, use this command in a #mentor-channel-* channel \
+or mention the channel as a second parameter",
+    )?;
+    text.create_permission(
+        &ctx,
+        &PermissionOverwrite {
+            kind: PermissionOverwriteType::Member(user),
+            allow: Permissions::READ_MESSAGES,
+            deny: Permissions::empty(),
+        },
+    )?;
+    voice.create_permission(
+        &ctx,
+        &PermissionOverwrite {
+            kind: PermissionOverwriteType::Member(user),
+            allow: Permissions::READ_MESSAGES,
+            deny: Permissions::empty(),
+        },
+    )?;
     msg.channel_id.say(&ctx, "User(s) added")?;
     Ok(())
 }

--- a/src/commands/cesium.rs
+++ b/src/commands/cesium.rs
@@ -205,7 +205,9 @@ pub fn join(ctx: &mut Context, msg: &Message, mut args: Args) -> CommandResult {
     let data_lock = ctx.data.read();
     let channels = data_lock.get::<ChannelMapping>().unwrap().read();
     let text = msg.channel_id;
-    let voice = channels.get_channel(&text).ok_or("Invalid channel")?;
+    let voice = channels
+        .get_channel(&text)
+        .ok_or("Invalid channel, use this command in a #mentor-channel-* channel")?;
     args.iter::<UserId>().try_for_each(|x| {
         x.map_err(|_| "invalid user id")
             .and_then(|u| {

--- a/src/commands/study.rs
+++ b/src/commands/study.rs
@@ -127,7 +127,7 @@ fn parse_study_args<'args, 'miei: 'args>(
                 None => roles
                     .roles_by_year(year.as_str())
                     .map(|rs| rs.filter(not_has_role).for_each(&mut push)),
-            }); 
+            });
         };
     }
     (ids, names)

--- a/src/daemons.rs
+++ b/src/daemons.rs
@@ -54,7 +54,7 @@ pub fn start_daemon_thread(
     fn run(d: &dyn Daemon, http: &Http) {
         let _ = d
             .run(http)
-            .map_err(|e| eprintln!("Deamon '{}' failed: {:?}", d.name(), e));
+            .map_err(|e| crate::log!("Deamon '{}' failed: {:?}", d.name(), e));
     }
     let list = daemons.iter().map(|d| d.read().name()).collect::<Vec<_>>();
     let (sx, rx) = mpsc::sync_channel(512);
@@ -87,15 +87,15 @@ pub fn start_daemon_thread(
                 }
                 match smallest_next_instant {
                     Some(s) => next_global_run = Some(s),
-                    None => break eprintln!("Deamon thread terminating"),
+                    None => break crate::log!("Deamon thread terminating"),
                 }
             }
-            Err(_) => break eprintln!("Deamon thread terminating"),
+            Err(_) => break crate::log!("Deamon thread terminating"),
         }
         let now = Instant::now();
         match next_global_run {
             Some(s) => thread::park_timeout(s - now),
-            None => break eprintln!("Deamon thread terminating"),
+            None => break crate::log!("Deamon thread terminating"),
         }
     });
     DaemonThread {

--- a/src/daemons/minecraft.rs
+++ b/src/daemons/minecraft.rs
@@ -140,7 +140,7 @@ impl Daemon for Minecraft {
                             }
                         }
                     }
-                    None => eprintln!("[Minecraft daemon]: '{}' not stored", name),
+                    None => crate::log!("[Minecraft daemon]: '{}' not stored", name),
                 }
             }
         }

--- a/src/daemons/minecraft.rs
+++ b/src/daemons/minecraft.rs
@@ -113,7 +113,7 @@ impl Daemon for Minecraft {
                 .find(':')
                 .ok_or_else(|| format!("Invalid online list: {}", online_list))?;
             let (_, list) = online_list.split_at(index + ':'.len_utf8());
-            for name in list.split(',').map(str::trim) {
+            for name in list.split(',').map(str::trim).filter(|x| !x.is_empty()) {
                 match self.names.get(name) {
                     Some(uuid) => {
                         let member = guild_id.member(http, uuid)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,9 @@ impl EventHandler for Handler {
             .map_err(|e| {
                 log!(
                     "Couldn't log user {} (nickname {}) leaving the server. Error: {:?}",
-                    user.name, nick, e
+                    user.name,
+                    nick,
+                    e
                 )
             })
             .ok();

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ impl EventHandler for Handler {
         println!("Up and running");
         if let Some(id) = ctx.data.read().get::<UpdateNotify>() {
             ChannelId::from(**id)
-                .send_message(&ctx, |m| m.content("Updated successfully!"))
+                .send_message(&ctx, |m| m.content("Rebooted successfully!"))
                 .expect("Couldn't send update notification");
         }
         ctx.data.write().remove::<UpdateNotify>();
@@ -143,10 +143,15 @@ fn main() {
         data.insert::<ChannelMapping>(Arc::new(RwLock::new(
             ChannelMapping::load().unwrap_or_default(),
         )));
-        let mc = Arc::new(RwLock::new(Minecraft::load().unwrap_or_default()));
-        data.insert::<Minecraft>(Arc::clone(&mc));
-        let dt = daemons::start_daemon_thread(vec![mc], Arc::clone(&client.cache_and_http.http));
-        data.insert::<daemons::DaemonThread>(dt);
+        if let Ok(_) = util::minecraft_server_get(&["list"]) {
+            let mc = Arc::new(RwLock::new(Minecraft::load().unwrap_or_default()));
+            data.insert::<Minecraft>(Arc::clone(&mc));
+            data.insert::<daemons::DaemonThread>(daemons::start_daemon_thread(
+                vec![mc],
+                Arc::clone(&client.cache_and_http.http),
+            ));
+        }
+
     }
     client.with_framework(
         StandardFramework::new()

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,9 +11,17 @@ where
     let mut output = Command::new("./server_do.sh")
         .args(args)
         .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()?
         .wait_with_output()?;
     let o_len = output.stdout.len();
-    output.stdout.truncate(o_len - 5);
-    Ok(output)
+    output.stdout.truncate(o_len.saturating_sub(5));
+    if output.status.success() {
+        Ok(output)
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            String::from_utf8_lossy(&output.stdout) + String::from_utf8_lossy(&output.stderr),
+        ))
+    }
 }


### PR DESCRIPTION
- Adds the `reboot` command, which simply reboots the bot
- Improves `cesium join` error message to better suggest what to do
- Improves `cesium join` to take a channel mention so it can be used outside the rooms
- Improve logging by prepending a timestamp to every log message
- Don't start the minecraft daemon if the server can't be found

