### PR TITLE
Add delayed tasks and mute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06d4a9551359071d1890820e3571252b91229e0712e7c36b08940e603c5a8fc"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b443e5fb0ddd56e0c9bfa47dc060c5306ee500cb731f2b91432dd65589a77684"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0220073ce504f12a70efc4e7cdaea9e9b1b324872e7ad96a208056d7a638b81"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +218,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0465971a8cc1fa2455c8465aaa377131e1f1cf4983280f474a13e68793aa770c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -331,6 +385,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghost"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +536,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
  "bytes 0.5.6",
+]
+
+[[package]]
+name = "inventory"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0f7efb804ec95e33db9ad49e4252f049e37e8b0a4652e3cd61f7999f2eff7f"
+dependencies = [
+ "ctor",
+ "ghost",
+ "inventory-impl",
+]
+
+[[package]]
+name = "inventory-impl"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c094e94816723ab936484666968f5b58060492e880f3c8d00489a1e244fa51"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -880,6 +973,7 @@ version = "0.1.0"
 dependencies = [
  "aho-corasick",
  "chrono",
+ "erased-serde",
  "futures",
  "itertools",
  "once_cell",
@@ -888,8 +982,11 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_with",
  "serenity",
  "tokio",
+ "toml",
+ "typetag",
 ]
 
 [[package]]
@@ -965,6 +1062,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b44be9227e214a0420707c9ca74c2d4991d9955bae9415a8f93f05cebf561be5"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48b35457e9d855d3dc05ef32a73e0df1e2c0fd72c38796a4ee909160c8eeec2"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serenity"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1152,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1132,6 +1257,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1349,30 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "typetag"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422619e1a7299befb977a1f6d8932c499f6151dbcafae715193570860cae8f07"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "lazy_static",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504f9626fe6cc1c376227864781996668e15c1ff251d222f63ef17f310bf1fec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "rusteze"
 version = "0.1.0"
 authors = ["Mendess2526 <pedro.mendes.26@gmail.com>"]
 edition = "2018"
+default-run = "rusteze"
 
 [dependencies]
 serenity = "0.10"
@@ -17,6 +18,11 @@ chrono = "0.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 futures = "0.3"
 pin-utils = "0.1"
+erased-serde = "0.3"
+typetag = "0.1"
+toml = "0.5"
+serde_with = "1"
+
 
 [profile.release]
 codegen-units = 1

--- a/src/bin/convert_config.rs
+++ b/src/bin/convert_config.rs
@@ -1,0 +1,14 @@
+use rusteze::config::Config;
+use std::fs::File;
+use std::io::{self, Read, Write};
+
+fn main() -> io::Result<()> {
+    let c = serde_json::from_reader::<_, Config>(File::open("config.json")?)?;
+    let c = toml::to_string(&c).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    File::create("config.toml")?.write_all(c.as_bytes())?;
+    let mut s = String::new();
+    File::open("config.toml")?.read_to_string(&mut s)?;
+    let c = toml::from_str::<Config>(&s).unwrap();
+    serde_json::to_writer_pretty(File::create("config2.json")?, &c)?;
+    Ok(())
+}

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -200,9 +200,7 @@ impl Year {
     }
 
     fn get_role<'a>(&self, role_name: &'a str) -> Option<&Course> {
-        self.courses
-            .values()
-            .find_map(|x| x.courses.get(role_name))
+        self.courses.values().find_map(|x| x.courses.get(role_name))
     }
 
     fn add_role(&mut self, role_name: &str, course: Course, semester: &str) {

--- a/src/commands/admin.rs
+++ b/src/commands/admin.rs
@@ -34,7 +34,7 @@ use serenity::{
     },
     prelude::*,
 };
-use std::{os::unix::process::CommandExt, process::Command as Fork, str, time::Instant};
+use std::{any::Any, os::unix::process::CommandExt, process::Command as Fork, str, time::Instant};
 use user_groups::*;
 
 #[group]
@@ -284,7 +284,7 @@ pub async fn mute(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult
     member
         .user
         .dm(&ctx, |m| {
-            m.content(format!("You've been muted for {} hours.", mute_role))
+            m.content(format!("You've been muted for {} hours.", muted_hours))
         })
         .await?;
     msg.channel_id.say(&ctx, "muted.").await?;
@@ -328,5 +328,17 @@ impl Task for Unmute {
             crate::log!("Umuted {}", uid);
         }
         Ok(())
+    }
+
+    fn is_diferent(&self, other: &dyn Any) -> bool {
+        if let Some(unmute) = other.downcast_ref::<Self>() {
+            unmute.user_id != self.user_id
+        } else {
+            true
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use crate::util::SendSyncError as Error;
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
 use serenity::{
     model::id::{ChannelId, RoleId},
     prelude::{RwLock, TypeMapKey},
@@ -10,6 +11,7 @@ use std::{
     sync::Arc,
 };
 
+#[serde_as]
 #[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Config {
     #[serde(default)]
@@ -21,7 +23,10 @@ pub struct Config {
     #[serde(default)]
     log_channel: Option<ChannelId>,
     #[serde(default)]
+    #[serde_as(as = "HashMap<DisplayFromStr, _>")]
     user_groups: HashMap<RoleId, String>,
+    #[serde(default)]
+    mute_role: Option<RoleId>,
 }
 
 const CONFIG: &str = "config.json";
@@ -104,6 +109,15 @@ impl Config {
 
     pub fn remove_user_group(&mut self, ch: RoleId) -> Result<(), Error> {
         self.user_groups.remove(&ch);
+        Config::serialize(self)
+    }
+
+    pub fn get_mute_role(&self) -> Option<RoleId> {
+        self.mute_role
+    }
+
+    pub fn set_mute_role(&mut self, rl: RoleId) -> Result<(), Error> {
+        self.mute_role = Some(rl);
         Config::serialize(self)
     }
 }

--- a/src/delayed_tasks/mod.rs
+++ b/src/delayed_tasks/mod.rs
@@ -1,0 +1,142 @@
+use chrono::{DateTime, Utc};
+use futures::future::FutureExt;
+use serenity::{
+    async_trait,
+    prelude::{TypeMap, TypeMapKey},
+};
+use std::{error::Error, fs::File, sync::Arc};
+use tokio::{
+    self,
+    sync::{
+        mpsc::{channel, error::SendError, Receiver, Sender},
+        Mutex, Notify,
+    },
+    time::timeout,
+};
+
+impl TypeMapKey for TaskSender {
+    type Value = Self;
+}
+
+const TASKS_PATH: &str = "tasks.json";
+
+#[typetag::serde(tag = "type")]
+#[async_trait]
+pub trait Task: Send + Sync {
+    fn when(&self) -> DateTime<Utc>;
+    async fn call(&mut self, user_data: &mut TypeMap) -> Result<(), Box<dyn Error>>;
+}
+
+pub struct TaskSender {
+    channel: Sender<Box<dyn Task>>,
+    notify: Arc<Notify>,
+}
+
+impl TaskSender {
+    fn new(channel: Sender<Box<dyn Task>>, notify: Arc<Notify>) -> Self {
+        Self { channel, notify }
+    }
+
+    pub async fn send(&self, task: Box<dyn Task>) -> Result<(), SendError<Box<dyn Task>>> {
+        self.channel.send(task).await?;
+        crate::log!("Sent a new task, notifying");
+        self.notify.notify_one();
+        Ok(())
+    }
+}
+
+pub struct DelayedTasks {
+    channel: Receiver<Box<dyn Task>>,
+    user_data: Arc<Mutex<TypeMap>>,
+    tasks: Vec<Box<dyn Task>>,
+    notify: Arc<Notify>,
+}
+
+impl DelayedTasks {
+    fn new(channel: Receiver<Box<dyn Task>>, t: TypeMap) -> std::io::Result<Self> {
+        let tasks = File::open(TASKS_PATH)
+            .map_err(|e| crate::log!("Failed to open tasks file for {:?} using empty vec", e))
+            .and_then(|f| {
+                serde_json::from_reader(f)
+                    .map_err(|e| crate::log!("Error parsing {}: {}", TASKS_PATH, e))
+            })
+            .unwrap_or_else(|_| Vec::new());
+        Ok(Self {
+            channel,
+            user_data: Arc::new(Mutex::new(t)),
+            tasks,
+            notify: Arc::new(Notify::new()),
+        })
+    }
+
+    fn receive(&mut self) -> bool {
+        loop {
+            match self.channel.recv().now_or_never() {
+                Some(Some(task)) => self.tasks.push(task),
+                None => break true,
+                Some(None) => break false,
+            }
+        }
+    }
+
+    fn run_tasks(&mut self) {
+        let mut i = 0;
+        while i < self.tasks.len() {
+            if self.tasks[i].when() < Utc::now() {
+                let mut t = self.tasks.remove(i);
+                let data = Arc::clone(&self.user_data);
+                tokio::spawn(async move {
+                    let _ = t
+                        .call(&mut *data.lock().await)
+                        .await
+                        .map_err(|e| crate::log!("{}", e));
+                });
+            } else {
+                i += 1;
+            }
+        }
+        self.serialize();
+    }
+
+    fn serialize(&self) {
+        File::create(TASKS_PATH)
+            .and_then(|d| serde_json::to_writer_pretty(d, &self.tasks).map_err(|e| e.into()))
+            .map_err(|e| crate::log!("{}", e))
+            .ok();
+    }
+
+    async fn run(mut self) {
+        while self.receive() || !self.tasks.is_empty() {
+            self.run_tasks();
+            match self.tasks.iter().map(|t| t.when()).min() {
+                None => self.notify.notified().await,
+                Some(smallest_timeout) => {
+                    match smallest_timeout.signed_duration_since(Utc::now()).to_std() {
+                        Ok(t) => {
+                            crate::log!("Sleeping for {:?}", t);
+                            let x = timeout(t, self.notify.notified()).await;
+                            crate::log!(
+                                "Woke because {}!",
+                                if x.is_ok() {
+                                    "was woken up"
+                                } else {
+                                    "it's time to run a task"
+                                }
+                            );
+                        }
+                        Err(e) => crate::log!("Scheduling to the past? {:?}", e),
+                    }
+                }
+            }
+        }
+        crate::log!("DelayedTasks terminating");
+    }
+}
+
+pub fn start(t: TypeMap) -> std::io::Result<TaskSender> {
+    let (sender, receiver) = channel(5);
+    let cron = DelayedTasks::new(receiver, t)?;
+    let notify = Arc::clone(&cron.notify);
+    tokio::spawn(async move { cron.run().await });
+    Ok(TaskSender::new(sender, notify))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ pub async fn after_hook(ctx: &Context, msg: &Message, cmd_name: &str, error: Com
             msg.author,
         ),
         Err(why) => {
-            let _ = msg.channel_id.say(ctx, &why);
+            let _ = msg.channel_id.say(ctx, &why).await;
             log!(
                 "Command '{}' for user '{}::{}' failed because {:?}",
                 cmd_name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,247 @@
+#![deny(unused_must_use)]
+
+pub mod channels;
+pub mod commands;
+pub mod config;
+pub mod daemons;
+pub mod delayed_tasks;
+pub mod util;
+
+use crate::config::Config;
+use serenity::{
+    framework::standard::{
+        help_commands,
+        macros::{help, hook},
+        Args, CommandGroup, CommandResult, DispatchError, HelpOptions,
+    },
+    model::{
+        channel::Message,
+        gateway::{Activity, Ready},
+        guild::Member,
+        id::{ChannelId, GuildId, UserId},
+        user::{OnlineStatus, User},
+    },
+    prelude::*,
+    utils::Colour,
+};
+use std::{collections::HashSet, sync::Arc};
+
+pub struct UpdateNotify;
+
+impl TypeMapKey for UpdateNotify {
+    type Value = Arc<u64>;
+}
+
+#[macro_export]
+macro_rules! log {
+    ($fmt:expr $(, $param:expr)*$(,)?) => {
+        eprintln!(
+            concat!("[{}] ", $fmt),
+            ::chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
+            $($param,)*
+        )
+    }
+}
+
+pub struct Handler;
+
+#[serenity::async_trait]
+impl EventHandler for Handler {
+    async fn ready(&self, ctx: Context, _ready: Ready) {
+        ctx.set_presence(Some(Activity::playing("$man")), OnlineStatus::Online)
+            .await;
+        crate::log!("Up and running");
+        if let Some(id) = ctx.data.read().await.get::<UpdateNotify>() {
+            ChannelId::from(**id)
+                .send_message(&ctx, |m| m.content("Rebooted successfully!"))
+                .await
+                .expect("Couldn't send update notification");
+        }
+        ctx.data.write().await.remove::<UpdateNotify>();
+    }
+
+    async fn guild_member_addition(&self, ctx: Context, guild_id: GuildId, new_member: Member) {
+        let share_map = ctx.data.read().await;
+        let config = share_map.get::<Config>().unwrap().read().await;
+        if let (Some(ch), Some(greet_message)) =
+            (config.greet_channel(), config.greet_channel_message())
+        {
+            let user = new_member.user.id;
+            let guild = guild_id.to_partial_guild(&ctx.http).await;
+            ch.send_message(&ctx, |m| {
+                m.content(user.mention());
+                m.embed(|e| {
+                    e.title("Bem-vindo(a) ao servidor de MIEI!");
+                    e.description(greet_message);
+                    e.thumbnail(guild.map(|u|u.icon_url().expect("No Guild Image available")).unwrap());
+                    e.colour(Colour::from_rgb(0, 0, 0));
+                    e.footer( |f| {
+                        f.text("Se tiveres alguma dúvida sobre o bot podes usar o comando $man para saberes o que podes fazer.");
+                        f
+                    });
+                    e
+                });
+                m
+            }).await.map_err(|e| log!("Couldn't greet new user {}: {:?}", user, e)).ok();
+        }
+    }
+
+    async fn guild_member_removal(
+        &self,
+        ctx: Context,
+        _: GuildId,
+        user: User,
+        member_data: Option<Member>,
+    ) {
+        let share_map = ctx.data.read().await;
+        let config = share_map.get::<Config>().unwrap().read().await;
+        if let Some(ch) = config.log_channel() {
+            let nick = member_data
+                .as_ref()
+                .and_then(|m| m.nick.as_ref().map(|s| s.as_str()))
+                .unwrap_or("None");
+            ch.send_message(&ctx, |m| {
+                m.embed(|e| {
+                    e.title("User left the server")
+                        .description(format!(
+                            "**Name:**      {}\n**Nickname:** {}",
+                            user.name, nick
+                        ))
+                        .thumbnail(
+                            user.avatar_url()
+                                .as_ref()
+                                .map(|s| s.as_str())
+                                .unwrap_or("https://i.imgur.com/lKmW0tc.png"),
+                        )
+                })
+            })
+            .await
+            .map_err(|e| {
+                log!(
+                    "Couldn't log user {} (nickname {}) leaving the server. Error: {:?}",
+                    user.name,
+                    nick,
+                    e
+                )
+            })
+            .ok();
+        }
+    }
+}
+
+#[help("man")]
+#[command_not_found_text("No manual entry for that")]
+#[max_levenshtein_distance(5)]
+#[lacking_permissions("hide")]
+#[strikethrough_commands_tip_in_guild(" ")]
+#[strikethrough_commands_tip_in_dm(" ")]
+async fn my_help(
+    context: &Context,
+    msg: &Message,
+    args: Args,
+    help_options: &'static HelpOptions,
+    groups: &[&'static CommandGroup],
+    owners: HashSet<UserId>,
+) -> CommandResult {
+    let _ = help_commands::with_embeds(context, msg, args, help_options, groups, owners).await;
+    Ok(())
+}
+
+#[hook]
+pub async fn before_hook(ctx: &Context, msg: &Message, _: &str) -> bool {
+    valid_channel(ctx, msg).await
+        || is_mc_cmd(ctx, msg).await
+        || is_admin(ctx, msg).await
+        || is_cesium_cmd(msg).await
+}
+
+#[hook]
+pub async fn after_hook(ctx: &Context, msg: &Message, cmd_name: &str, error: CommandResult) {
+    match error {
+        Ok(()) => log!(
+            "Processed command '{}' for user '{}::{}'",
+            cmd_name,
+            msg.author.name,
+            msg.author,
+        ),
+        Err(why) => {
+            let _ = msg.channel_id.say(ctx, &why);
+            log!(
+                "Command '{}' for user '{}::{}' failed because {:?}",
+                cmd_name,
+                msg.author.name,
+                msg.author,
+                why
+            )
+        }
+    }
+}
+
+#[hook]
+pub async fn dispatch_error_hook(ctx: &Context, msg: &Message, error: DispatchError) {
+    log!(
+        "Command '{}' for user '{}::{}' failed to dispatch because '{:?}'",
+        msg.content,
+        msg.author.name,
+        msg.author,
+        error
+    );
+    if let Some(s) = match error {
+        DispatchError::NotEnoughArguments { min: m, given: g } => {
+            Some(format!("Not enough arguments! min: {}, given: {}", m, g))
+        }
+        DispatchError::TooManyArguments { max: m, given: g } => {
+            Some(format!("Too many arguments! max: {}, given: {}", m, g))
+        }
+        _ => None,
+    } {
+        msg.channel_id
+            .say(ctx, s)
+            .await
+            .expect("Couldn't communicate dispatch error");
+    }
+}
+
+pub async fn valid_channel(ctx: &Context, msg: &Message) -> bool {
+    ctx.data
+        .read()
+        .await
+        .get::<Config>()
+        .unwrap()
+        .read()
+        .await
+        .channel_is_allowed(msg.channel_id)
+}
+
+pub async fn is_admin(ctx: &Context, msg: &Message) -> bool {
+    async fn _f(ctx: &Context, msg: &Message) -> Option<bool> {
+        Some(
+            msg.guild_id?
+                .member(&ctx.http, &msg.author)
+                .await
+                .ok()?
+                .permissions(&ctx)
+                .await
+                .ok()?
+                .administrator(),
+        )
+    }
+    _f(ctx, msg).await.unwrap_or(false)
+}
+
+pub async fn is_cesium_cmd(msg: &Message) -> bool {
+    msg.content.split_whitespace().next() == Some("$cesium")
+}
+
+pub async fn is_mc_cmd(ctx: &Context, msg: &Message) -> bool {
+    msg.content
+        .trim()
+        .trim_start_matches('$')
+        .starts_with("online")
+        && msg
+            .channel_id
+            .name(&ctx)
+            .await
+            .map(|name| name == "minecraft")
+            .unwrap_or_default()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,138 +1,18 @@
 #![deny(unused_must_use)]
 
-pub mod channels;
-mod commands;
-pub mod config;
-mod daemons;
-pub mod util;
-
-use crate::{
+use rusteze::{
     channels::{read_courses, MiEI},
     commands::{admin::*, cesium::*, misc::*, study::*, usermod::*},
     config::Config,
     daemons::minecraft::Minecraft,
+    delayed_tasks::TaskSender,
+    util::Endpoint,
+    *,
 };
 use serenity::{
-    framework::standard::{
-        help_commands,
-        macros::{help, hook},
-        Args, CommandGroup, CommandResult, DispatchError, HelpOptions, StandardFramework,
-    },
-    model::{
-        channel::Message,
-        gateway::{Activity, Ready},
-        guild::Member,
-        id::{ChannelId, GuildId, UserId},
-        user::{OnlineStatus, User},
-    },
-    prelude::*,
-    utils::Colour,
-    client::bridge::gateway::GatewayIntents,
+    client::bridge::gateway::GatewayIntents, framework::standard::StandardFramework, prelude::*,
 };
-use std::{collections::HashSet, fs, sync::Arc};
-
-struct UpdateNotify;
-
-impl TypeMapKey for UpdateNotify {
-    type Value = Arc<u64>;
-}
-
-#[macro_export]
-macro_rules! log {
-    ($fmt:expr $(, $param:expr)*$(,)?) => {
-        eprintln!(
-            concat!("[{}] ", $fmt),
-            ::chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
-            $($param,)*
-        )
-    }
-}
-
-struct Handler;
-
-#[serenity::async_trait]
-impl EventHandler for Handler {
-    async fn ready(&self, ctx: Context, _ready: Ready) {
-        ctx.set_presence(Some(Activity::playing("$man")), OnlineStatus::Online)
-            .await;
-        crate::log!("Up and running");
-        if let Some(id) = ctx.data.read().await.get::<UpdateNotify>() {
-            ChannelId::from(**id)
-                .send_message(&ctx, |m| m.content("Rebooted successfully!"))
-                .await
-                .expect("Couldn't send update notification");
-        }
-        ctx.data.write().await.remove::<UpdateNotify>();
-    }
-
-    async fn guild_member_addition(&self, ctx: Context, guild_id: GuildId, new_member: Member) {
-        let share_map = ctx.data.read().await;
-        let config = share_map.get::<Config>().unwrap().read().await;
-        if let (Some(ch), Some(greet_message)) =
-            (config.greet_channel(), config.greet_channel_message())
-        {
-            let user = new_member.user.id;
-            let guild = guild_id.to_partial_guild(&ctx.http).await;
-            ch.send_message(&ctx, |m| {
-                m.content(user.mention());
-                m.embed(|e| {
-                    e.title("Bem-vindo(a) ao servidor de MIEI!");
-                    e.description(greet_message);
-                    e.thumbnail(guild.map(|u|u.icon_url().expect("No Guild Image available")).unwrap());
-                    e.colour(Colour::from_rgb(0, 0, 0));
-                    e.footer( |f| {
-                        f.text("Se tiveres alguma dúvida sobre o bot podes usar o comando $man para saberes o que podes fazer.");
-                        f
-                    });
-                    e
-                });
-                m
-            }).await.map_err(|e| log!("Couldn't greet new user {}: {:?}", user, e)).ok();
-        }
-    }
-
-    async fn guild_member_removal(
-        &self,
-        ctx: Context,
-        _: GuildId,
-        user: User,
-        member_data: Option<Member>,
-    ) {
-        let share_map = ctx.data.read().await;
-        let config = share_map.get::<Config>().unwrap().read().await;
-        if let Some(ch) = config.log_channel() {
-            let nick = member_data
-                .as_ref()
-                .and_then(|m| m.nick.as_ref().map(|s| s.as_str()))
-                .unwrap_or("None");
-            ch.send_message(&ctx, |m| {
-                m.embed(|e| {
-                    e.title("User left the server")
-                        .description(format!(
-                            "**Name:**      {}\n**Nickname:** {}",
-                            user.name, nick
-                        ))
-                        .thumbnail(
-                            user.avatar_url()
-                                .as_ref()
-                                .map(|s| s.as_str())
-                                .unwrap_or("https://i.imgur.com/lKmW0tc.png"),
-                        )
-                })
-            })
-            .await
-            .map_err(|e| {
-                log!(
-                    "Couldn't log user {} (nickname {}) leaving the server. Error: {:?}",
-                    user.name,
-                    nick,
-                    e
-                )
-            })
-            .ok();
-        }
-    }
-}
+use std::{fs, sync::Arc};
 
 #[tokio::main]
 async fn main() {
@@ -183,124 +63,14 @@ async fn main() {
             daemons::start_daemon_thread(vec![mc], Arc::clone(&client.cache_and_http)).await,
         );
     }
+    {
+        let mut tasks_data = TypeMap::new();
+        tasks_data.insert::<Endpoint>(Endpoint::from(&*client.cache_and_http));
+        client.data.write().await.insert::<TaskSender>(
+            delayed_tasks::start(tasks_data).expect("Couldn't start delayed tasks"),
+        );
+    }
     if let Err(why) = client.start().await {
         log!("Client error: {:?}", why);
     }
-}
-
-#[help("man")]
-#[command_not_found_text("No manual entry for that")]
-#[max_levenshtein_distance(5)]
-#[lacking_permissions("hide")]
-#[strikethrough_commands_tip_in_guild(" ")]
-#[strikethrough_commands_tip_in_dm(" ")]
-async fn my_help(
-    context: &Context,
-    msg: &Message,
-    args: Args,
-    help_options: &'static HelpOptions,
-    groups: &[&'static CommandGroup],
-    owners: HashSet<UserId>,
-) -> CommandResult {
-    let _ = help_commands::with_embeds(context, msg, args, help_options, groups, owners).await;
-    Ok(())
-}
-
-#[hook]
-async fn before_hook(ctx: &Context, msg: &Message, _: &str) -> bool {
-    valid_channel(ctx, msg).await
-        || is_mc_cmd(ctx, msg).await
-        || is_admin(ctx, msg).await
-        || is_cesium_cmd(msg).await
-}
-
-#[hook]
-async fn after_hook(ctx: &Context, msg: &Message, cmd_name: &str, error: CommandResult) {
-    match error {
-        Ok(()) => log!(
-            "Processed command '{}' for user '{}::{}'",
-            cmd_name,
-            msg.author.name,
-            msg.author,
-        ),
-        Err(why) => {
-            let _ = msg.channel_id.say(ctx, &why);
-            log!(
-                "Command '{}' for user '{}::{}' failed because {:?}",
-                cmd_name,
-                msg.author.name,
-                msg.author,
-                why
-            )
-        }
-    }
-}
-
-#[hook]
-async fn dispatch_error_hook(ctx: &Context, msg: &Message, error: DispatchError) {
-    log!(
-        "Command '{}' for user '{}::{}' failed to dispatch because '{:?}'",
-        msg.content,
-        msg.author.name,
-        msg.author,
-        error
-    );
-    if let Some(s) = match error {
-        DispatchError::NotEnoughArguments { min: m, given: g } => {
-            Some(format!("Not enough arguments! min: {}, given: {}", m, g))
-        }
-        DispatchError::TooManyArguments { max: m, given: g } => {
-            Some(format!("Too many arguments! max: {}, given: {}", m, g))
-        }
-        _ => None,
-    } {
-        msg.channel_id
-            .say(ctx, s)
-            .await
-            .expect("Couldn't communicate dispatch error");
-    }
-}
-
-async fn valid_channel(ctx: &Context, msg: &Message) -> bool {
-    ctx.data
-        .read()
-        .await
-        .get::<Config>()
-        .unwrap()
-        .read()
-        .await
-        .channel_is_allowed(msg.channel_id)
-}
-
-async fn is_admin(ctx: &Context, msg: &Message) -> bool {
-    async fn _f(ctx: &Context, msg: &Message) -> Option<bool> {
-        Some(
-            msg.guild_id?
-                .member(&ctx.http, &msg.author)
-                .await
-                .ok()?
-                .permissions(&ctx)
-                .await
-                .ok()?
-                .administrator(),
-        )
-    }
-    _f(ctx, msg).await.unwrap_or(false)
-}
-
-async fn is_cesium_cmd(msg: &Message) -> bool {
-    msg.content.split_whitespace().next() == Some("$cesium")
-}
-
-async fn is_mc_cmd(ctx: &Context, msg: &Message) -> bool {
-    msg.content
-        .trim()
-        .trim_start_matches('$')
-        .starts_with("online")
-        && msg
-            .channel_id
-            .name(&ctx)
-            .await
-            .map(|name| name == "minecraft")
-            .unwrap_or_default()
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,12 @@
+use serenity::{
+    cache::Cache,
+    http::{CacheHttp, Http},
+    prelude::TypeMapKey,
+};
 use std::{
     io,
     process::{Command, Output, Stdio},
+    sync::Arc,
 };
 
 pub fn minecraft_server_get<I, S>(args: I) -> io::Result<Output>
@@ -27,3 +33,47 @@ where
 }
 
 pub type SendSyncError = Box<dyn std::error::Error + Send + Sync>;
+
+pub struct Endpoint {
+    http: Arc<Http>,
+    cache: Arc<Cache>,
+}
+
+impl From<&serenity::CacheAndHttp> for Endpoint {
+    fn from(cache_and_http: &serenity::CacheAndHttp) -> Self {
+        Self {
+            http: cache_and_http.http.clone(),
+            cache: cache_and_http.cache.clone(),
+        }
+    }
+}
+
+impl CacheHttp for Endpoint {
+    fn http(&self) -> &Http {
+        &*self.http
+    }
+
+    fn cache(&self) -> Option<&Arc<Cache>> {
+        Some(&self.cache)
+    }
+}
+
+impl AsRef<Http> for Endpoint {
+    fn as_ref(&self) -> &Http {
+        &*self.http
+    }
+}
+
+impl TypeMapKey for Endpoint {
+    type Value = Endpoint;
+}
+
+#[macro_export]
+macro_rules! get {
+    ($ctx:ident, $t:ty) => {
+        $ctx.data.read().await.get::<$t>().unwrap()
+    };
+    (mut $ctx:ident, $t:ty) => {
+        $ctx.data.write().await.get_mut::<$t>().unwrap()
+    };
+}


### PR DESCRIPTION
Adds

- `$sudo set_mute_role @role`
- `$sudo mute @user [time]`

To implement this [DeplayedTasks](https://github.com/MIEIdiscord/Rusteze/blob/mute/src/delayed_tasks/mod.rs) was created. In the future daemons might be implementable in function of this. But that's for another PR

There was also an idea I played with of having `config.json` being a `config.toml` and made a program that does the conversion. Don't know if it's good or worth it.

**The important bit**: https://github.com/MIEIdiscord/Rusteze/blob/58a6b23db39633d56511d3d332933e3e0bf0403d/src/commands/admin.rs#L258-L292

